### PR TITLE
Many small fixes and code cleanup for sdmsh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ cscope.out
 tags
 .gitignore
 sdmsh
-convert
+sampleconv

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 cscope.out
 tags
 .gitignore
+sdmsh
+convert

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ endif
 RLINC = `pkg-config --cflags readline`
 RLLIB = `pkg-config --libs ${STATIC} readline`
 
-CFLAGS += -W -Wall -I. -I$(LIBSDM_DIR) -I$(LIBSTRM_DIR) -ggdb -DLOGGER_ENABLED -fPIC ${RLINC}
+CFLAGS += -Wall -Wextra -I. -I$(LIBSDM_DIR) -I$(LIBSTRM_DIR) -ggdb -DLOGGER_ENABLED -fPIC ${RLINC}
 ifdef WITH_ADDRESS_SANITAZE
 	CFLAGS  += -fsanitize=address
 	LDFLAGS += -fsanitize=address

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ DOCKER_RUN = docker run --rm -it \
                 -e USER=$(USER) -e HOST_UID=$$(id -u) -e HOST_GID=$$(id -g) \
                 evologicsgmbh/crosscompile-sandbox
 
-all: build
+all: build sampleconv
 
 build: lib $(OBJ)
 	$(CC) -o $(PROJ) $(OBJ) $(LIBSDM_A) $(LIBSTRM_A) -L. $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -24,17 +24,26 @@ LIBSTRM_DIR = lib/$(LIBSTRM)
 LIBSTRM_SO  = $(LIBSTRM_DIR)/$(LIBSTRM).so
 LIBSTRM_A   = $(LIBSTRM_DIR)/$(LIBSTRM).a
 
-CFLAGS += -W -Wall -I. -I$(LIBSDM_DIR) -I$(LIBSTRM_DIR) -ggdb -DLOGGER_ENABLED -fPIC
+ifdef BUILD_STATIC_BIN
+STATIC = --static
+endif
+
+RLINC = `pkg-config --cflags readline`
+RLLIB = `pkg-config --libs ${STATIC} readline`
+
+CFLAGS += -W -Wall -I. -I$(LIBSDM_DIR) -I$(LIBSTRM_DIR) -ggdb -DLOGGER_ENABLED -fPIC ${RLINC}
 ifdef WITH_ADDRESS_SANITAZE
 	CFLAGS  += -fsanitize=address
 	LDFLAGS += -fsanitize=address
 endif
 
 ifdef BUILD_STATIC_BIN
-    LDFLAGS += -static -l:libreadline.a -l:libtinfo.a -l:libncurses.a
+    LDFLAGS += -static -l:libtinfo.a -l:libncurses.a
 else
-    LDFLAGS += -lreadline -ltinfo -lncurses
+    LDFLAGS += -ltinfo -lncurses
 endif
+
+LDFLAGS += ${RLLIB}
 
 ifdef COMPAT_READLINE6
     SRC     +=  compat/readline6.c

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ $(LIBSDM_A) $(LIBSDM_SO):
 clean:
 	${MAKE} -C $(LIBSDM_DIR) clean
 	${MAKE} -C $(LIBSTRM_DIR) clean
-	rm -f $(PROJ) $(OBJ) *~ .*.sw? *.so core
+	rm -f $(PROJ) $(OBJ) *~ .*.sw? *.so core *.core
 
 dist-clean: clean
 	rm -f cscope.out tags

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ endif
 RLINC = `pkg-config --cflags readline`
 RLLIB = `pkg-config --libs ${STATIC} readline`
 
-CFLAGS += -Wall -Wextra -I. -I$(LIBSDM_DIR) -I$(LIBSTRM_DIR) -ggdb -DLOGGER_ENABLED -fPIC ${RLINC}
+CFLAGS += -Wall -Wextra -I. -I$(LIBSDM_DIR) -I$(LIBSTRM_DIR) -ggdb -DLOGGER_ENABLED -D_GNU_SOURCE -fPIC ${RLINC}
 ifdef WITH_ADDRESS_SANITAZE
 	CFLAGS  += -fsanitize=address
 	LDFLAGS += -fsanitize=address
@@ -55,6 +55,8 @@ DOCKER_RUN = docker run --rm -it \
                 -v $(HOME)/.bash_history:$(HOME)/.bash_history \
                 -e USER=$(USER) -e HOST_UID=$$(id -u) -e HOST_GID=$$(id -g) \
                 evologicsgmbh/crosscompile-sandbox
+
+all: build
 
 build: lib $(OBJ)
 	$(CC) -o $(PROJ) $(OBJ) $(LIBSDM_A) $(LIBSTRM_A) -L. $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ else
     LDFLAGS += -ltinfo -lncurses
 endif
 
-LDFLAGS += ${RLLIB}
+LDFLAGS += ${RLLIB} -lm
 
 ifdef COMPAT_READLINE6
     SRC     +=  compat/readline6.c

--- a/Makefile
+++ b/Makefile
@@ -70,16 +70,16 @@ sandbox-devshell:
 
 .PHONY: lib
 lib:
-	make -C $(LIBSTRM_DIR)
-	make -C $(LIBSDM_DIR)
+	${MAKE} -C $(LIBSTRM_DIR)
+	${MAKE} -C $(LIBSDM_DIR)
 
 $(LIBSDM_A) $(LIBSDM_SO):
-	make -C $(LIBSTRM_DIR)
-	make -C $(LIBSDM_DIR)
+	${MAKE} -C $(LIBSTRM_DIR)
+	${MAKE} -C $(LIBSDM_DIR)
 
 clean:
-	make -C $(LIBSDM_DIR) clean
-	make -C $(LIBSTRM_DIR) clean
+	${MAKE} -C $(LIBSDM_DIR) clean
+	${MAKE} -C $(LIBSTRM_DIR) clean
 	rm -f $(PROJ) $(OBJ) *~ .*.sw? *.so core
 
 dist-clean: clean

--- a/TODO
+++ b/TODO
@@ -1,3 +1,7 @@
+- why is input int16, while output is uint16?
+- sdmsh_commands.c:262
+- sdm.c:265:sdm_send() va_arg(int) vs va_arg(long)
+
 + fix autocomplition for raw:,ascii:,tcp:
 + do nothing by `history`if there is no interactive mode
 + skip `history` command from history

--- a/TODO
+++ b/TODO
@@ -7,7 +7,6 @@
 + skip `history` command from history
 + handle ctrl-c for cleaning current command. can interrupt usleep 100000
 + driver "tcp:" cannot be used for tx.
-+ add command `source`
 + add possibillity put multiply options `-f` to read many script files
 + add autodetect filetype by extention *.raw -> raw:, .dat,txt -> ascii:
 
@@ -31,7 +30,6 @@
   this must fix problems with redraw prompt in call rl_callback_read_char()
 
 - add to command `tx` possibillity get singals from several files
-- add command `exit`
 - add command `set`. and variable `log_level`
 - add parameters to scripts like $1, $2..
 - add support libsox for .wav files and resampling

--- a/convert.c
+++ b/convert.c
@@ -1,0 +1,145 @@
+#include <stdbool.h>
+#include <unistd.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+typedef int16_t i16;
+
+void error (const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start (ap, fmt);
+	fprintf (stderr, "convert: ");
+	vfprintf (stderr, fmt, ap);
+	fputc ('\n', stderr);
+	va_end (ap);
+	exit (1);
+}
+
+// READ FUNCTIONS
+
+typedef bool(*read_t)(FILE *, i16 *);
+
+bool read_float (FILE *file, i16 *x)
+{
+	char line[32], *endp;
+	double d;
+	long i;
+
+	if (fgets (line, sizeof (line), file) == NULL)
+		return false;
+
+	d = strtod (line, &endp);
+	if (*endp != '\0' && *endp != '\n')
+		error ("invalid float: %s", line);
+
+	i = (long)(d * 32767);
+	if (i < -32768 || i > 32767)
+		error ("out of range: %s", line);
+
+	*x = (i16)i;
+	return true;
+}
+
+bool read_int (FILE *file, i16 *x)
+{
+	char line[32], *endp;
+	long i;
+
+	if (fgets (line, sizeof (line), file) == NULL)
+		return false;
+
+	i = strtol (line, &endp, 10);
+	if (*endp != '\0' && *endp != '\n')
+		error ("invalid int: %s", line);
+
+	if (i < -32768 || i > 32767)
+		error ("out of range: %s", line);
+
+	*x = (i16)i;
+	return true;
+}
+
+bool read_bin (FILE *file, i16 *x)
+{
+	char b[2];
+	if (fread (b, 2, 1, file) != 2)
+		return false;
+	*x = (i16)b[0] | ((i16)b[1] << 8);
+	return true;
+}
+
+// WRiTE FUNCTIONS
+
+typedef void(*write_t)(FILE *, i16);
+
+void write_float (FILE *file, i16 x)
+{
+	fprintf (file, "%f\n", (float)x / 32767);
+}
+
+void write_int (FILE *file, i16 x)
+{
+	fprintf (file, "%d\n", (int)x);
+}
+
+void write_bin (FILE *file, i16 x)
+{
+	char b[2];
+	b[0] = x & 0xff;
+	b[1] = x >> 8;
+	fwrite (b, 2, 1, file);
+}
+
+int usage (void)
+{
+	fputs ("usage: convert [-i filetype] [-o filetype]\n", stderr);
+	return 1;
+}
+
+int main (int argc, char *argv[])
+{
+	read_t rfunc = read_float;
+	write_t wfunc = write_bin;
+	int option;
+	i16 x;
+
+	while ((option = getopt (argc, argv, "i:o:")) != -1) {
+		switch (option) {
+		case 'i':
+			if (strcmp (optarg, "float") == 0) {
+				rfunc = read_float;
+			} else if (strcmp (optarg, "int") == 0) {
+				rfunc = read_int;
+			} else if (strcmp (optarg, "bin") == 0) {
+				rfunc = read_bin;
+			} else {
+				error ("invalid input type: %s", optarg);
+			}
+			break;
+		case 'o':
+			if (strcmp (optarg, "float") == 0) {
+				wfunc = write_float;
+			} else if (strcmp (optarg, "int") == 0) {
+				wfunc = write_int;
+			} else if (strcmp (optarg, "bin") == 0) {
+				wfunc = write_bin;
+			} else {
+				error ("invalid input type: %s", optarg);
+			}
+			break;
+		default:
+			return usage ();
+		}
+	}
+
+	while (rfunc (stdin, &x))
+		wfunc (stdout, x);
+
+
+	return 0;
+}

--- a/lib/libsdm/Makefile
+++ b/lib/libsdm/Makefile
@@ -3,7 +3,7 @@ PROJ = libsdm
 SRC = sdm.c utils.c janus/janus.c
 OBJ = $(SRC:.c=.o)
 
-CFLAGS = -W -Wall -I. -I../libstream -L../libstream -lstream -lm -ggdb -DLOGGER_ENABLED -fPIC
+CFLAGS = -Wall -Wextra -I. -I../libstream -L../libstream -lstream -lm -ggdb -DLOGGER_ENABLED -fPIC
 
 $(PROJ): $(PROJ).so $(PROJ).a
 

--- a/lib/libsdm/Makefile
+++ b/lib/libsdm/Makefile
@@ -3,7 +3,7 @@ PROJ = libsdm
 SRC = sdm.c utils.c janus/janus.c
 OBJ = $(SRC:.c=.o)
 
-CFLAGS = -Wall -Wextra -I. -I../libstream -L../libstream -lstream -lm -ggdb -DLOGGER_ENABLED -fPIC
+CFLAGS = -Wall -Wextra -I. -I../libstream -L../libstream -lstream -lm -ggdb -DLOGGER_ENABLED -D_GNU_SOURCE -fPIC
 
 $(PROJ): $(PROJ).so $(PROJ).a
 

--- a/lib/libsdm/janus/janus.c
+++ b/lib/libsdm/janus/janus.c
@@ -1,4 +1,3 @@
-#define _GNU_SOURCE
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/lib/libsdm/sdm.c
+++ b/lib/libsdm/sdm.c
@@ -12,6 +12,7 @@
 #include <stdlib.h>     /* stdlib() */
 #include <assert.h>
 #include <limits.h>     /* SHORT_MAX  */
+#include <inttypes.h>   /* PRIu32  */
 #include <sys/time.h>   /* struct timeval  */
 
 #include <sdm.h>
@@ -392,14 +393,14 @@ int sdm_show(sdm_session_t *ss, sdm_pkt_t *cmd)
             logger(INFO_LOG, "          \n");
             break;
         case SDM_REPLY_BUSY:
-            logger(INFO_LOG, "%d\n", cmd->param);
+            logger(INFO_LOG, "%"PRId32"\n", cmd->param);
             break;
         case SDM_REPLY_SYSTIME:
             if (cmd->data_len == 8) {
-                logger (INFO_LOG, "current_time = %u, tx_time = %u, rx_time = %u, syncin_time = %u\n"
+                logger (INFO_LOG, "current_time = %"PRIu32", tx_time = %"PRIu32", rx_time = %"PRIu32", syncin_time = %"PRIu32"\n"
                        , cmd->current_time, cmd->tx_time, cmd->rx_time, cmd->syncin_time);
             } else {
-                logger (INFO_LOG, "current_time = %u, tx_time = %u, rx_time = %u\n"
+                logger (INFO_LOG, "current_time = %"PRIu32", tx_time = %"PRIu32", rx_time = %"PRIu32"\n"
                        , cmd->current_time, cmd->tx_time, cmd->rx_time);
             }
             break;
@@ -411,26 +412,26 @@ int sdm_show(sdm_session_t *ss, sdm_pkt_t *cmd)
             float janus_doppler;
             memcpy(&janus_nshift, &ss->rx_data[0], 4);
             memcpy(&janus_doppler, &ss->rx_data[4], 4);
-            logger (INFO_LOG, " janus_nshift = %d, janus_doppler = %f\n", janus_nshift, janus_doppler);
+            logger (INFO_LOG, " janus_nshift = %"PRId32", janus_doppler = %f\n", janus_nshift, janus_doppler);
             break;
         }
         case SDM_REPLY_REPORT:
             switch (cmd->param) {
                 case SDM_REPLY_REPORT_NO_SDM_MODE: logger(INFO_LOG, " %s\n", sdm_reply_report_to_str(SDM_REPLY_REPORT_NO_SDM_MODE)); break;
-                case SDM_REPLY_REPORT_TX_STOP:     logger(INFO_LOG, " %s after %d samples\n", sdm_reply_report_to_str(cmd->param), cmd->data_len); break;
-                case SDM_REPLY_REPORT_RX_STOP:     logger(INFO_LOG, " %s after %d samples\n", sdm_reply_report_to_str(cmd->param), cmd->data_len); break;
+                case SDM_REPLY_REPORT_TX_STOP:     logger(INFO_LOG, " %s after %"PRIu32" samples\n", sdm_reply_report_to_str(cmd->param), cmd->data_len); break;
+                case SDM_REPLY_REPORT_RX_STOP:     logger(INFO_LOG, " %s after %"PRIu32" samples\n", sdm_reply_report_to_str(cmd->param), cmd->data_len); break;
                 case SDM_REPLY_REPORT_REF:         logger(INFO_LOG, " %s %s\n", sdm_reply_report_to_str(cmd->param),    cmd->data_len ? "done":"fail"); break;
                 case SDM_REPLY_REPORT_CONFIG:      logger(INFO_LOG, " %s %s\n", sdm_reply_report_to_str(cmd->param), cmd->data_len ? "done":"fail"); break;
                 case SDM_REPLY_REPORT_USBL_CONFIG: logger(INFO_LOG, " %s %s\n", sdm_reply_report_to_str(cmd->param), cmd->data_len ? "done":"fail"); break;
-                case SDM_REPLY_REPORT_USBL_RX_STOP:logger(INFO_LOG, " %s %s\n", sdm_reply_report_to_str(cmd->param), cmd->data_len); break;
-                case SDM_REPLY_REPORT_DROP:        logger(INFO_LOG, " %s %d\n", sdm_reply_report_to_str(cmd->param), cmd->data_len); break;
+                case SDM_REPLY_REPORT_USBL_RX_STOP:logger(INFO_LOG, " %s %"PRIu32"\n", sdm_reply_report_to_str(cmd->param), cmd->data_len); break;
+                case SDM_REPLY_REPORT_DROP:        logger(INFO_LOG, " %s %"PRIu32"\n", sdm_reply_report_to_str(cmd->param), cmd->data_len); break;
                 case SDM_REPLY_REPORT_SYSTIME:     logger(INFO_LOG, " %s fail\n", sdm_reply_report_to_str(cmd->param)); break;
-                case SDM_REPLY_REPORT_UNKNOWN:     logger(INFO_LOG, " %s 0x%02x\n", sdm_reply_report_to_str(cmd->param), cmd->data_len); break;
-                default:  logger(WARN_LOG, " Uknown reply report 0x%02x\n", cmd->param); break;
+                case SDM_REPLY_REPORT_UNKNOWN:     logger(INFO_LOG, " %s 0x%"PRIx32"\n", sdm_reply_report_to_str(cmd->param), cmd->data_len); break;
+                default:  logger(WARN_LOG, " Uknown reply report 0x%02x\n", (unsigned)cmd->param); break;
             }
             break;
         default:
-            logger(WARN_LOG, "Uknown reply command 0x%02x\n", cmd->cmd);
+            logger(WARN_LOG, "Uknown reply command 0x%02x\n", (unsigned)cmd->cmd);
             break;
     }
 

--- a/lib/libsdm/sdm.c
+++ b/lib/libsdm/sdm.c
@@ -289,6 +289,8 @@ int sdm_send(sdm_session_t *ss, int cmd_code, ...)
         if (data_len) {
             logger(TRACE_LOG, "tx cmd continue: %d samples              \n", data_len);
             n = write(ss->sockfd, data, data_len * 2);
+        } else {
+            n = 0;
         }
     } else {
         sdm_pack_cmd(cmd, cmd_raw);
@@ -882,3 +884,4 @@ int sdm_receive_data_time_limit(sdm_session_t *ssl[], long time_limit)
     return rc;
 }
 
+/* vim: set ts=4 sw=4 et: */

--- a/lib/libsdm/sdm.c
+++ b/lib/libsdm/sdm.c
@@ -273,14 +273,14 @@ int sdm_send(sdm_session_t *ss, int cmd_code, ...)
 
     if (cmd_code == SDM_CMD_TX_CONTINUE) {
         if (data_len) {
-            logger(TRACE_LOG, "tx cmd continue: %d samples              \n", data_len);
+            logger(TRACE_LOG, "tx cmd continue: %"PRIu32" samples              \n", data_len);
             n = write(ss->sockfd, data, data_len * 2);
         } else {
             n = 0;
         }
     } else {
         sdm_pack_cmd(cmd, cmd_raw);
-        logger(INFO_LOG, "tx cmd %-6s: %d samples ", sdm_cmd_to_str(cmd->cmd), data_len);
+        logger(INFO_LOG, "tx cmd %-6s: %"PRIu32" samples ", sdm_cmd_to_str(cmd->cmd), data_len);
         DUMP_SHORT(DEBUG_LOG, LGREEN, cmd_raw, SDM_PKT_T_SIZE + data_len * 2);
         logger(INFO_LOG, "\n");
         n = write(ss->sockfd, cmd_raw, SDM_PKT_T_SIZE + data_len * 2);
@@ -600,7 +600,7 @@ int sdm_handle_rx_data(sdm_session_t *ss, char *buf, int len)
         case SDM_REPLY_SYSTIME:
             /* cmd->data_len in header in uint16 count */
             if (handled - data_len < (int)ss->cmd->data_len * 2) {
-                logger(INFO_LOG, "\rwaiting %d bytes\r", ss->cmd->data_len * 2 - handled - data_len);
+                logger(INFO_LOG, "\rwaiting %"PRIu32" bytes\r", ss->cmd->data_len * 2 - handled - data_len);
                 return 0;
             }
 
@@ -615,7 +615,7 @@ int sdm_handle_rx_data(sdm_session_t *ss, char *buf, int len)
         case SDM_REPLY_JANUS_DETECTED:
             /* cmd->data_len in header in uint16 count */
             if (handled - data_len < (int)ss->cmd->data_len * 2) {
-                logger(INFO_LOG, "\rwaiting %d bytes\r", ss->cmd->data_len * 2 - handled - data_len);
+                logger(INFO_LOG, "\rwaiting %"PRIu32" bytes\r", ss->cmd->data_len * 2 - handled - data_len);
                 return 0;
             }
 

--- a/lib/libsdm/sdm.c
+++ b/lib/libsdm/sdm.c
@@ -1,4 +1,3 @@
-#define _GNU_SOURCE
 #include <stdio.h>
 #include <unistd.h>     /* write() */
 #include <err.h>        /* err() */

--- a/lib/libsdm/sdm.c
+++ b/lib/libsdm/sdm.c
@@ -360,11 +360,15 @@ char* sdm_reply_report_to_str(uint8_t cmd)
 int sdm_show(sdm_session_t *ss, sdm_pkt_t *cmd)
 {
     char *buf;
+    int len;
 
     logger((sdm_is_async_reply(cmd->cmd) ? ASYNC_LOG : INFO_LOG)
             , "\rrx cmd %-6s: ", sdm_reply_to_str(cmd->cmd));
     sdm_pack_reply(cmd, &buf);
-    DUMP_SHORT(DEBUG_LOG, YELLOW, buf, SDM_PKT_T_SIZE + cmd->data_len * 2);
+    len = SDM_PKT_T_SIZE;
+    if (cmd->cmd != SDM_REPLY_REPORT)
+        len += cmd->data_len * 2;
+    DUMP_SHORT(DEBUG_LOG, YELLOW, buf, len);
     free(buf);
 
     switch (cmd->cmd) {

--- a/lib/libsdm/utils.c
+++ b/lib/libsdm/utils.c
@@ -326,7 +326,7 @@ char *sstrpad(char *src, size_t pad)
     }
     buf[0] = 0;
     if (pad >= len) {
-        strcat(buf, src);
+        strlcat(buf, src, sizeof (buf));
         memset(&buf[len], ' ', pad - len);
         buf[pad] = 0;
     } else {

--- a/lib/libstream/Makefile
+++ b/lib/libstream/Makefile
@@ -3,7 +3,7 @@ PROJ = libstream
 SRC = stream.c stream_raw.c stream_ascii.c stream_tcp.c stream_popen.c
 OBJ = $(SRC:.c=.o)
 
-CFLAGS = -Wall -Wextra -I. -lm -ggdb -DLOGGER_ENABLED -fPIC
+CFLAGS = -Wall -Wextra -I. -lm -ggdb -DLOGGER_ENABLED -D_GNU_SOURCE -fPIC
 
 $(PROJ): $(PROJ).so $(PROJ).a
 

--- a/lib/libstream/Makefile
+++ b/lib/libstream/Makefile
@@ -3,7 +3,7 @@ PROJ = libstream
 SRC = stream.c stream_raw.c stream_ascii.c stream_tcp.c stream_popen.c
 OBJ = $(SRC:.c=.o)
 
-CFLAGS = -W -Wall -I. -lm -ggdb -DLOGGER_ENABLED -fPIC
+CFLAGS = -Wall -Wextra -I. -lm -ggdb -DLOGGER_ENABLED -fPIC
 
 $(PROJ): $(PROJ).so $(PROJ).a
 

--- a/lib/libstream/stream.c
+++ b/lib/libstream/stream.c
@@ -41,11 +41,11 @@ stream_t *stream_new_v(int direction, const char* driver, const char* args)
     glob_t g;
 
     memset (&g, 0, sizeof (g));
-    // FIXME: Don't use strcpy(3)
+    // FIXME: check return value of strncpy()
     if (glob (args, GLOB_NOCHECK | GLOB_TILDE, NULL, &g) == 0) {
-        strcpy (stream->args, g.gl_pathv[0]);
+        strncpy (stream->args, g.gl_pathv[0], sizeof (stream->args));
     } else {
-        strcpy (stream->args, args);
+        strncpy (stream->args, args, sizeof (stream->args));
     }
     globfree (&g);
 

--- a/lib/libstream/stream.c
+++ b/lib/libstream/stream.c
@@ -15,6 +15,10 @@
     int stream_impl_ ## a ## _new(stream_t*);
 #include "stream.def"
 
+#ifndef GLOB_TILDE
+# define GLOB_TILDE 0
+#endif
+
 static const char* s_drivers[] = {
 #define STREAM(a) #a,
 #include "stream.def"

--- a/lib/libstream/stream_ascii.c
+++ b/lib/libstream/stream_ascii.c
@@ -217,7 +217,7 @@ static int stream_impl_read(const stream_t *stream, uint16_t* samples, unsigned 
                 if (val > 1.0 || val < -1.0)
                     STREAM_RETURN_ERROR("Error float data do not normalized", ERANGE);
 
-                samples[data_offset++] = (uint16_t)(val * SHRT_MAX);
+                samples[data_offset++] = (int16_t)(val * SHRT_MAX);
                 break;
             case STREAM_ASCII_FILE_TYPE_INT:
                 if (val < SHRT_MIN || val > SHRT_MAX) {
@@ -225,7 +225,7 @@ static int stream_impl_read(const stream_t *stream, uint16_t* samples, unsigned 
                     STREAM_RETURN_ERROR("Error int data must be 16bit", ERANGE);
 		}
             
-                samples[data_offset++] = (uint16_t)val;
+                samples[data_offset++] = (int16_t)val;
                 break;
         }
         n++;

--- a/lib/libstream/stream_ascii.c
+++ b/lib/libstream/stream_ascii.c
@@ -8,6 +8,8 @@
 #include <string.h>
 #include <errno.h>
 #include <limits.h>
+#include <ctype.h>
+#include <math.h>
 
 #include <stream.h>
 

--- a/lib/libstream/stream_ascii.c
+++ b/lib/libstream/stream_ascii.c
@@ -148,7 +148,7 @@ static float myatof (const char *s)
 		f += (*s - '0') * x;
 
 skip:
-	f = sign * (f * ival);
+	f = sign * (f + ival);
 
 	if (*s != 'e' && *s != 'E')
 		return f;

--- a/lib/libstream/stream_ascii.c
+++ b/lib/libstream/stream_ascii.c
@@ -241,7 +241,7 @@ int stream_impl_ascii_new(stream_t *stream)
     stream->strerror     = stream_impl_strerror;
     stream->get_error_op = stream_impl_get_error_op;
     stream->count        = stream_impl_count;
-    strcpy(stream->name, "ASCII");
+    strncpy(stream->name, "ASCII", sizeof (stream->name));
 
     return STREAM_ERROR_NONE;
 }

--- a/lib/libstream/stream_ascii.c
+++ b/lib/libstream/stream_ascii.c
@@ -182,7 +182,7 @@ static int stream_impl_write(stream_t *stream, void* samples, unsigned int sampl
         STREAM_RETURN_ERROR("writing file", ENOTSUP);
 
     for (i = 0; i < sample_count; i++)
-        if (fprintf (pdata->fp, "%d\n", ((uint16_t*)samples)[i]) < 0)
+        if (fprintf (pdata->fp, "%d\n", ((int16_t*)samples)[i]) < 0)
             STREAM_RETURN_ERROR("writing file", errno);
 
     return sample_count;

--- a/lib/libstream/stream_popen.c
+++ b/lib/libstream/stream_popen.c
@@ -140,7 +140,7 @@ int stream_impl_popen_new(stream_t *stream)
     stream->strerror     = stream_impl_strerror;
     stream->get_error_op = stream_impl_get_error_op;
     stream->count        = stream_impl_count;
-    strcpy(stream->name, "POPEN");
+    strncpy(stream->name, "POPEN", sizeof (stream->name));
 
     return STREAM_ERROR_NONE;
 }

--- a/lib/libstream/stream_raw.c
+++ b/lib/libstream/stream_raw.c
@@ -148,7 +148,7 @@ int stream_impl_raw_new(stream_t *stream)
     stream->strerror     = stream_impl_strerror;
     stream->get_error_op = stream_impl_get_error_op;
     stream->count        = stream_impl_count;
-    strcpy(stream->name, "RAW");
+    strncpy(stream->name, "RAW", sizeof (stream->name));
 
     return STREAM_ERROR_NONE;
 }

--- a/lib/libstream/stream_tcp.c
+++ b/lib/libstream/stream_tcp.c
@@ -244,7 +244,7 @@ int stream_impl_tcp_new(stream_t *stream)
     stream->strerror     = stream_impl_strerror;
     stream->get_error_op = stream_impl_get_error_op;
     stream->count        = stream_impl_count;
-    strcpy(stream->name, "TCP");
+    strncpy(stream->name, "TCP", sizeof (stream->name));
 
     return STREAM_ERROR_NONE;
 }

--- a/lib/libstream/stream_tcp.c
+++ b/lib/libstream/stream_tcp.c
@@ -111,6 +111,7 @@ static int stream_impl_open(stream_t *stream)
     if (!socket_type || !ip_s || !port_s) {
         pdata->error = EINVAL;
         pdata->error_op = "arguments parsing";
+        rc = STREAM_ERROR;
         goto stream_impl_open_finish;
     }
     port = atoi(port_s);
@@ -126,6 +127,7 @@ static int stream_impl_open(stream_t *stream)
     } else {
         pdata->error = EINVAL;
         pdata->error_op = "connection type";
+        rc = STREAM_ERROR;
     }
     if (rc < 0) {
         pdata->error = errno;

--- a/sampleconv.c
+++ b/sampleconv.c
@@ -40,6 +40,9 @@ bool read_float (FILE *file, i16 *x)
 	if (*endp != '\0' && *endp != '\n')
 		error ("invalid float: %s", line);
 
+	if (d < -1.0 || d > 1.0)
+		error ("out of range: %s", line);
+
 	i = (long)(d * 32767);
 	if (i < -32768 || i > 32767)
 		error ("out of range: %s", line);

--- a/sampleconv.c
+++ b/sampleconv.c
@@ -1,3 +1,4 @@
+// converts samples between text and binary formats
 #include <stdbool.h>
 #include <unistd.h>
 #include <string.h>
@@ -13,7 +14,7 @@ void error (const char *fmt, ...)
 	va_list ap;
 
 	va_start (ap, fmt);
-	fprintf (stderr, "convert: ");
+	fprintf (stderr, "sampleconv: ");
 	vfprintf (stderr, fmt, ap);
 	fputc ('\n', stderr);
 	va_end (ap);
@@ -97,7 +98,7 @@ void write_bin (FILE *file, i16 x)
 
 int usage (void)
 {
-	fputs ("usage: convert [-i filetype] [-o filetype]\n", stderr);
+	fputs ("usage: sampleconv [-i filetype] [-o filetype]\n", stderr);
 	return 1;
 }
 

--- a/sampleconv.c
+++ b/sampleconv.c
@@ -7,7 +7,9 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+typedef uint16_t u16;
 typedef int16_t i16;
+typedef unsigned char uchar;
 
 void error (const char *fmt, ...)
 {
@@ -67,10 +69,11 @@ bool read_int (FILE *file, i16 *x)
 
 bool read_bin (FILE *file, i16 *x)
 {
-	char b[2];
-	if (fread (b, 2, 1, file) != 2)
+	uchar b[2];
+	if (fread (b, 2, 1, file) != 1)
 		return false;
-	*x = (i16)b[0] | ((i16)b[1] << 8);
+
+	*x = (u16)b[0] | ((u16)b[1] << 8);
 	return true;
 }
 
@@ -90,7 +93,7 @@ void write_int (FILE *file, i16 x)
 
 void write_bin (FILE *file, i16 x)
 {
-	char b[2];
+	uchar b[2];
 	b[0] = x & 0xff;
 	b[1] = x >> 8;
 	fwrite (b, 2, 1, file);

--- a/sdmsh.c
+++ b/sdmsh.c
@@ -251,6 +251,8 @@ int main(int argc, char *argv[])
         } else {
             host = argv[optind - 1];
         }
+    } else {
+        host = NULL;
     }
 
     if (flags & FLAG_SHOW_HELP)

--- a/sdmsh.c
+++ b/sdmsh.c
@@ -246,7 +246,7 @@ int main(int argc, char *argv[])
         long num = strtol(argv[optind - 1], &endptr, 10);
 
         if (endptr != NULL && *endptr == 0 && num >= 1 && num <= 254) {
-            sprintf (host_, "192.168.0.%lu", num);
+            snprintf (host_, sizeof (host_), "192.168.0.%lu", num);
             host = host_;
         } else {
             host = argv[optind - 1];

--- a/sdmsh_commands.c
+++ b/sdmsh_commands.c
@@ -64,7 +64,7 @@ struct driver_t drivers[] = {
 
 int sdmsh_cmd_help(struct shell_config *sc, char *argv[], int argc)
 {
-    argc = argc;
+    (void)argc;
     shell_help_show(sc, argv[1]);
     return 0;
 }
@@ -110,7 +110,7 @@ int sdmsh_cmd_stop(struct shell_config *sc, char *argv[], int argc)
 {
     sdm_session_t *ss = sc->cookie;
 
-    argv = argv;
+    (void)argv;
     ARGS_RANGE(argc == 1);
     sdm_send(ss, SDM_CMD_STOP);
     sdm_set_idle_state(ss);
@@ -360,7 +360,7 @@ int sdmsh_cmd_waitsyncin(struct shell_config *sc, char *argv[], int argc)
 {
     sdm_session_t *ss = sc->cookie;
 
-    argv = argv;
+    (void)argv;
     ARGS_RANGE(argc == 1);
     sdm_set_idle_state(ss);
     ss->state = SDM_STATE_WAIT_SYNCIN;
@@ -371,7 +371,7 @@ int sdmsh_cmd_waitsyncin(struct shell_config *sc, char *argv[], int argc)
 int sdmsh_cmd_usleep(struct shell_config *sc, char *argv[], int argc)
 {
     useconds_t usec;
-    sc = sc;
+    (void)sc;
 
     ARGS_RANGE(argc == 2);
     SDM_CHECK_STR_ARG_LONG("usleep: usec", argv[1], usec, arg >= 0);
@@ -383,7 +383,7 @@ int sdmsh_cmd_usleep(struct shell_config *sc, char *argv[], int argc)
 int sdmsh_cmd_history(struct shell_config *sc, char *argv[], int argc)
 {
     int hist_num = 10;
-    sc = sc;
+    (void)sc;
 
     ARGS_RANGE(argc == 1 || argc == 2);
     if (argc == 2)
@@ -414,8 +414,8 @@ int sdmsh_cmd_source(struct shell_config *sc, char *argv[], int argc)
 
 int sdmsh_cmd_exit(struct shell_config *sc, char *argv[], int argc)
 {
-    argv = argv;
-    argc = argc;
+    (void)argc;
+    (void)argv;
     sc->shell_quit = 2;
     return 0;
 }

--- a/sdmsh_commands.c
+++ b/sdmsh_commands.c
@@ -82,7 +82,7 @@ int sdmsh_cmd_config(struct shell_config *sc, char *argv[], int argc)
     if (argc == 5) {
         SDM_CHECK_STR_ARG_LONG("config: preamp gain", argv[4], preamp_gain, arg >= 0 && arg <= 13);
     }
-    sdm_send(ss, SDM_CMD_CONFIG, threshold, gain, srclvl, preamp_gain);
+    sdm_send(ss, SDM_CMD_CONFIG, (unsigned)threshold, (unsigned)gain, (unsigned)srclvl, (unsigned)preamp_gain);
     sdm_set_idle_state(ss);
 
     return 0;
@@ -100,7 +100,7 @@ int sdmsh_cmd_usbl_config(struct shell_config *sc, char *argv[], int argc)
     SDM_CHECK_STR_ARG_LONG("usbl_config: gain", argv[3], gain, arg >= 0 && arg <= 13);
     SDM_CHECK_STR_ARG_LONG("usbl_config: sample_rate", argv[4], sample_rate, arg >= 0 && arg <= 6);
 
-    sdm_send(ss, SDM_CMD_USBL_CONFIG, delay, samples, gain, sample_rate);
+    sdm_send(ss, SDM_CMD_USBL_CONFIG, (unsigned)delay, (unsigned)samples, (unsigned)gain, (unsigned)sample_rate);
     sdm_set_idle_state(ss);
 
     return 0;
@@ -162,7 +162,7 @@ int sdmsh_cmd_ref(struct shell_config *sc, char *argv[], int argc)
         }
 
         /* DUMP2LOG(ERR_LOG, (char *)data, len*2); */
-        rc = sdm_send(ss, SDM_CMD_REF, data, len);
+        rc = sdm_send(ss, SDM_CMD_REF, data, (unsigned)len);
     }
 
     stream_close(stream);
@@ -235,11 +235,11 @@ int sdmsh_cmd_tx(struct shell_config *sc, char *argv[], int argc)
         logger(DATA_LOG, "tx data %d / %d / %d samples  \r", nsamples, len, passed);
 
         if (cnt == len && nsamples >= 1024) {
-            rc = sdm_send(ss, cmd, nsamples, data, len);
+            rc = sdm_send(ss, cmd, (unsigned)nsamples, data, (unsigned)len);
             passed += len;
         } else if (cnt > 0) {
             memset(&data[cnt], 0, (len - cnt) * 2);
-            rc = sdm_send(ss, cmd, nsamples, data, 1024 * ((cnt + 1023) / 1024));
+            rc = sdm_send(ss, cmd, (unsigned)nsamples, data, (unsigned)(1024 * ((cnt + 1023) / 1024)));
             passed += 1024 * ((cnt + 1023) / 1024);
         } else {
             rc = -1;
@@ -301,7 +301,7 @@ int sdmsh_cmd_rx_helper(struct shell_config *sc, char *argv[], int argc, int cod
         return -1;
     }
 
-    sdm_send(ss, code, nsamples);
+    sdm_send(ss, code, (unsigned long)nsamples);
     /* rl_message("Waiting for receiving %ld samples to file %s\n", nsamples, ss->filename); */
     
     return 0;
@@ -340,7 +340,7 @@ int sdmsh_cmd_usbl_rx(struct shell_config *sc, char *argv[], int argc)
             logger(ERR_LOG, "usbl_rx: error %s\n", stream_strerror(stream));
         return -1;
     }
-    sdm_send(ss, SDM_CMD_USBL_RX, channel, samples);
+    sdm_send(ss, SDM_CMD_USBL_RX, (unsigned)channel, (unsigned)samples);
     
     return 0;
 }

--- a/shell.c
+++ b/shell.c
@@ -206,13 +206,16 @@ int shell_make_argv(char *cmd_line, char ***argv, int *argc)
 {
     glob_t g;
 
-    switch (glob (cmd_line, GLOB_NOCHECK | GLOB_TILDE, NULL, &g)) {
-    case 0:
+    if (glob (cmd_line, GLOB_NOCHECK | GLOB_TILDE, NULL, &g) == 0) {
         *argc = g.gl_pathc;
         *argv = g.gl_pathv;
         return 0;
+    }
+
+    switch (errno) {
     case GLOB_NOSPACE:
         globfree (&g);
+        // fallthrough
     default:
         return -1;
     }

--- a/shell.c
+++ b/shell.c
@@ -1,6 +1,3 @@
-/* for asprintf() */
-#define _GNU_SOURCE
-
 #include <assert.h>
 #include <err.h>
 #include <stdarg.h>

--- a/shell.c
+++ b/shell.c
@@ -285,7 +285,7 @@ int rl_hook_argv_getch(FILE *in)
     static char prev_ch = 0;
     char ch;
     struct shell_input *si;
-    in = in;
+    (void)in;
 
     si = STAILQ_FIRST(&shell_config->inputs_list);
     if (*si->pos != 0) {

--- a/shell.h
+++ b/shell.h
@@ -9,6 +9,10 @@
 #define _GNU_SOURCE
 #endif
 
+#ifndef __linux__
+typedef void (*sighandler_t)(int);
+#endif
+
 #include <stdio.h> /* FILE* */
 #include <signal.h>
 

--- a/shell_completion.c
+++ b/shell_completion.c
@@ -30,14 +30,16 @@ static char* shell_rl_driver_completion(const char *text, int index)
         if (drv->flags & SCF_DRIVER_FILENAME && strstart((char *)text, drv->name)) {
             char *fn;
             char *fn_with_prefix;
+	    size_t len_fwp;
 
             rl_filename_completion_desired = 1;
             fn = rl_filename_completion_function(text + strlen(drv->name), index - cnt);
             if (!fn)
                 return NULL;
 
-            fn_with_prefix = malloc(strlen(fn) + strlen(drv->name) + 1 + 1);
-            sprintf(fn_with_prefix, "%s%s", drv->name, fn);
+	    len_fwp = strlen (fn) + strlen (drv->name) + 1 + 1;
+            fn_with_prefix = malloc(len_fwp);
+            snprintf(fn_with_prefix, len_fwp, "%s%s", drv->name, fn);
             free(fn);
             return fn_with_prefix;
         }

--- a/shell_completion.c
+++ b/shell_completion.c
@@ -164,7 +164,7 @@ static int shell_filter_scripts_names(char **names)
 static char** shell_cb_completion(const char *text, int start, int end)
 {
     char **matches = NULL;
-    end = end;
+    (void)end;
 
     rl_ignore_some_completions_function = NULL;
 
@@ -188,7 +188,8 @@ static char** shell_cb_completion(const char *text, int start, int end)
 
 static char* shell_rl_hook_dummy(const char *text, int state)
 {
-    text = text; state = state;
+    (void)text;
+    (void)state;
     return NULL;
 }
 

--- a/shell_history.c
+++ b/shell_history.c
@@ -1,4 +1,3 @@
-#define _GNU_SOURCE
 #include <stdio.h> /* asprintf() */
 #include <stdlib.h>
 


### PR DESCRIPTION
- add `sampleconv` utility to convert between sample formats
- portability fixes (now works on OpenBSD)
- `printf()` format string related fixes
- varargs fixes
- replace libc's slow `strtod()` with custom `myatof()` to make sending data directly from the modem feasible
- replace usage of unsafe string functions (such as `strcpy()`, `sprintf()`) with slightly more safe alternatives (`strncpy()`, `snprintf()`)
- fix the build system (see [my mk branch](https://github.com/realchonk/sdmsh/tree/mk) for a better solution)
- replace usage of the [harmful `wordexp(3)` API](https://www.cipht.net/2023/11/21/worried-by-wordexp.html) with much more sane `glob(3)`